### PR TITLE
chore: 修正资源包遵循协议CC-BY-4.0的链接，删除正文所在行的二级标题符

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Any usage issues can ask for help via
 
 ## License
 
-deepin-tool-kit is licensed under [CC-BY-4.0](LICENSE).
+deepin-tool-kit is licensed under [CC-BY-4.0](LICENSES/CC-BY-4.0.txt).

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -1,6 +1,6 @@
 ## Deepin desktop theme
 
-## Deepin desktop theme 提供精心设计的各种主题资源，包括图标主题资源， 光标主题资源等.
+Deepin desktop theme 提供精心设计的各种主题资源，包括图标主题资源， 光标主题资源等.
 
 
 ## 帮助
@@ -15,4 +15,4 @@
 
 ## 协议
 
-资源包遵循协议 [CC-BY-4.0](LICENSE).
+资源包遵循协议 [CC-BY-4.0](LICENSES/CC-BY-4.0.txt).


### PR DESCRIPTION
修正协议链接：LICENSE -> LICENSES/CC-BY-4.0.txt
删除位于标题“Deepin desktop theme”下方文字介绍中行首多余的二极标题符