### PR TITLE
chore: bump version to 1.0.9

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-desktop-theme (1.0.9) unstable; urgency=medium
+
+  * chore: 删除多余的dci图标
+  * invalid GTK icon cache
+  * chore: Modify icon name
+
+ -- bluesky <chenchongbiao@deepin.org>  Thu, 16 Nov 2023 10:31:21 +0800
+
 deepin-desktop-theme (1.0.8) unstable; urgency=medium
 
   * fix organic-glass and square theme


### PR DESCRIPTION
chore: 删除多余的dci图标
invalid GTK icon cache (linuxdeepin/developer-center/issues/4291)
chore: Modify icon name (linuxdeepin/developer-center/issues/6099)

Log: bump version