### PR TITLE
chore: link deepin-home icon from bloom to bloom-dark theme

### DIFF
--- a/bloom/dsg-icons/bloom-dark/deepin-home.dci
+++ b/bloom/dsg-icons/bloom-dark/deepin-home.dci
@@ -1,0 +1,1 @@
+../bloom/deepin-home.dci


### PR DESCRIPTION
as title

pms: BUG-307317