### PR TITLE
chore: remove unnecessary quotation marks from the Name field

### DIFF
--- a/hazy-color/icons/hazy-color/cursor.theme
+++ b/hazy-color/icons/hazy-color/cursor.theme
@@ -1,2 +1,2 @@
 [Icon Theme]
-Name="hazy color"
+Name=hazy color

--- a/macaron/icons/macaron/cursor.theme
+++ b/macaron/icons/macaron/cursor.theme
@@ -1,2 +1,2 @@
 [Icon Theme]
-Name="macaron"
+Name=macaron

--- a/organic-glass/icons/organic-glass/cursor.theme
+++ b/organic-glass/icons/organic-glass/cursor.theme
@@ -1,2 +1,2 @@
 [Icon Theme]
-Name="organic glass"
+Name=organic glass

--- a/square/icons/square/cursor.theme
+++ b/square/icons/square/cursor.theme
@@ -1,2 +1,2 @@
 [Icon Theme]
-Name="square"
+Name=square


### PR DESCRIPTION
The writing conventions for 'cursor.theme' are the same as those for 'index.theme'. XDG does not require the Name field in 'index.theme' to be enclosed in quotation marks

pms: BUG-286363
pms: BUG-286359

## Summary by Sourcery

Chores:
- Remove unnecessary quotation marks from the Name field in cursor.theme files.