### PR TITLE
chore: bump version to 1.1.6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-theme (1.1.6) unstable; urgency=medium
+
+  * chore: remove unnecessary quotation marks from the Name field
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 27 Mar 2025 17:48:58 +0800
+
 deepin-desktop-theme (1.1.5) unstable; urgency=medium
 
   * chore: link deepin-home icon from bloom to bloom-dark theme


### PR DESCRIPTION
update changelog to 1.1.6

## Summary by Sourcery

Chores:
- Bump package version number in the Debian changelog