### PR TITLE
chore: bump version to 1.1.7

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-desktop-theme (1.1.7) unstable; urgency=medium
+
+  * chore: update theme
+  * chore: remove theme wallpaper
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Tue, 29 Apr 2025 14:18:13 +0800
+
 deepin-desktop-theme (1.1.6) unstable; urgency=medium
 
   * chore: remove unnecessary quotation marks from the Name field


### PR DESCRIPTION
update changelog to 1.1.7

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 1.1.7.