### PR TITLE
style: update theme to use light wallpaper variant

### DIFF
--- a/organic-glass/deepin-themes/organic-glass/index.theme
+++ b/organic-glass/deepin-themes/organic-glass/index.theme
@@ -21,8 +21,8 @@ WindowRadius=12
 WindowOpacity=0.4
 WindowShadow=#DDDDDD
 ActiveColor=#1F6EE7
-Wallpaper=file:///usr/share/wallpapers/deepin/organic-glass-dark.jpg
-LockBackground=file:///usr/share/wallpapers/deepin/organic-glass-dark.jpg
+Wallpaper=file:///usr/share/wallpapers/deepin/organic-glass-light.jpg
+LockBackground=file:///usr/share/wallpapers/deepin/organic-glass-light.jpg
 IconTheme=organic-glass
 CursorTheme=organic-glass
 


### PR DESCRIPTION
organic-glass 默认壁纸设置为浅色的壁纸

pms: BUG-315979

## Summary by Sourcery

Update the default wallpaper in the organic-glass theme to use the light variant.