### PR TITLE
feat: add deepin-scanner icon symlinks

### DIFF
--- a/flow/dsg-icons/flow/deepin-scanner.dci
+++ b/flow/dsg-icons/flow/deepin-scanner.dci
@@ -1,0 +1,1 @@
+org.deepin.scanner.dci

--- a/hazy-color/dsg-icons/hazy-color/deepin-scanner.dci
+++ b/hazy-color/dsg-icons/hazy-color/deepin-scanner.dci
@@ -1,0 +1,1 @@
+org.deepin.scanner.dci

--- a/macaron/dsg-icons/macaron/deepin-scanner.dci
+++ b/macaron/dsg-icons/macaron/deepin-scanner.dci
@@ -1,0 +1,1 @@
+org.deepin.scanner.dci

--- a/nirvana/dsg-icons/nirvana/deepin-scanner.dci
+++ b/nirvana/dsg-icons/nirvana/deepin-scanner.dci
@@ -1,0 +1,1 @@
+org.deepin.scanner.dci

--- a/organic-glass/dsg-icons/organic-glass/deepin-scanner.dci
+++ b/organic-glass/dsg-icons/organic-glass/deepin-scanner.dci
@@ -1,0 +1,1 @@
+org.deepin.scanner.dci

--- a/square/dsg-icons/square/deepin-scanner.dci
+++ b/square/dsg-icons/square/deepin-scanner.dci
@@ -1,0 +1,1 @@
+org.deepin.scanner.dci

--- a/vintage/dsg-icons/vintage/deepin-scanner.dci
+++ b/vintage/dsg-icons/vintage/deepin-scanner.dci
@@ -1,0 +1,1 @@
+org.deepin.scanner.dci


### PR DESCRIPTION
1. Added symbolic links for deepin-scanner.dci across multiple icon
themes (flow, hazy-color, macaron, nirvana, organic-glass, square,
vintage)
2. Each symlink points to org.deepin.scanner.dci
3. This ensures the scanner icon is available in all theme variants
4. Symlinks maintain consistency while avoiding duplicate files

feat: 添加 deepin-scanner 图标符号链接

1. 在多个图标主题中为 deepin-scanner.dci 添加符号链接（flow, hazy-color,
macaron, nirvana, organic-glass, square, vintage）
2. 每个符号链接都指向 org.deepin.scanner.dci
3. 确保扫描仪图标在所有主题变体中可用
4. 符号链接保持一致性同时避免文件重复

pms:BUG-318933

## Summary by Sourcery

New Features:
- Add deepin-scanner icon symlinks in flow, hazy-color, macaron, nirvana, organic-glass, square, and vintage icon themes