### PR TITLE
chore: remove redundant icon installation path

### DIFF
--- a/debian/deepin-theme-nirvana.install
+++ b/debian/deepin-theme-nirvana.install
@@ -1,2 +1,1 @@
 usr/share/*/nirvana*
-usr/share/*/*/nirvana*


### PR DESCRIPTION
1. Removed the secondary icon installation path from debian package
2. The icons have been moved to public directory and no longer need this installation path
3. Simplifies package installation by reducing unnecessary file operations

chore: 移除冗余的图标安装路径

1. 从 debian 包中移除了二级图标安装路径
2. 图标已移动到公共目录，不再需要此安装路径
3. 通过减少不必要的文件操作简化了包安装