### PR TITLE
chore: bump version to 1.1.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-theme (1.1.11) unstable; urgency=medium
+
+  * chore: update theme
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 08 Aug 2025 09:43:33 +0800
+
 deepin-desktop-theme (1.1.10) unstable; urgency=medium
 
   * feat: add xdgicon2dci tool and update build configuration


### PR DESCRIPTION
update changelog to 1.1.11

## Summary by Sourcery

Build:
- Update debian/changelog to reflect version 1.1.11