### PR TITLE
chore: remove redundant icon symlinks

### DIFF
--- a/icons/inode-directory.dci；
+++ b/icons/inode-directory.dci；
@@ -1,1 +1,0 @@
-folder.dci

--- a/icons/notification-change-failed.dci；
+++ b/icons/notification-change-failed.dci；
@@ -1,1 +1,0 @@
-notification-change-language-failed.dci

--- a/icons/notification-change-finished.dci；
+++ b/icons/notification-change-finished.dci；
@@ -1,1 +1,0 @@
-notification-change-language-finished.dci

--- a/icons/notification-change-start.dci；
+++ b/icons/notification-change-start.dci；
@@ -1,1 +1,0 @@
-notification-change-language-start.dci

--- a/icons/user-desktop.dci；
+++ b/icons/user-desktop.dci；
@@ -1,1 +1,0 @@
-folder-desktop.dci


### PR DESCRIPTION
1. Deleted 5 unnecessary symbolic links in icons directory
2. Links were pointing to existing files with different names
3. Removal simplifies the codebase by eliminating duplicate references
4. These symlinks were likely created accidentally or for temporary purposes

chore: 删除多余的图标符号链接

1. 删除了icons目录中5个不必要的符号链接
2. 这些链接指向不同名称的现有文件
3. 通过消除重复引用简化了代码库
4. 这些符号链接可能是意外创建或临时使用的

## Summary by Sourcery

Chores:
- Delete five redundant icon symlinks from the icons directory.