### PR TITLE
chore: bump version to 1.1.13

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-theme (1.1.13) unstable; urgency=medium
+
+  * chore: remove redundant icon symlinks
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 21 Aug 2025 19:48:32 +0800
+
 deepin-desktop-theme (1.1.12) unstable; urgency=medium
 
   * fix: update all network icons to common folder.


### PR DESCRIPTION
update changelog to 1.1.13

## Summary by Sourcery

Build:
- Update the Debian changelog to reflect version 1.1.13