### PR TITLE
fix: remove exit call in postinst script

### DIFF
--- a/debian/deepin-desktop-theme.postinst
+++ b/debian/deepin-desktop-theme.postinst
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 ICON_CONVERTER="/usr/libexec/deepin-desktop-theme/xdgicon2dci"
 THEME_NAME="hicolor"
 TARGET_DIR="/usr/share/dsg/icons"
@@ -16,7 +14,6 @@ case "$1" in
         ;;
     *)
         echo "postinst called with unknown argument \`$1'" >&2
-        exit 1
         ;;
 esac
 


### PR DESCRIPTION
1. Removed the 'set -e' command that makes script exit on any error
2. Removed the 'exit 1' call in the default case handler
3. This prevents package installation failures when postinst encounters unknown arguments
4. The script should continue execution rather than aborting installation

fix: 移除 postinst 脚本中的退出调用

1. 移除了导致脚本在任何错误时退出的 'set -e' 命令
2. 移除了默认情况处理程序中的 'exit 1' 调用
3. 这可以防止在 postinst 遇到未知参数时导致包安装失败
4. 脚本应该继续执行而不是中止安装过程

## Summary by Sourcery

Relax error handling in the postinst script to avoid aborting package installation on unknown arguments

Bug Fixes:
- Prevent package installation failures when postinst encounters unknown arguments

Enhancements:
- Remove 'set -e' directive from postinst script
- Remove 'exit 1' call from the default case handler in postinst