### PR TITLE
feat: add user-desktop symlinks for icon themes

### DIFF
--- a/bloom/dsg-icons/bloom-dark/user-desktop.dci
+++ b/bloom/dsg-icons/bloom-dark/user-desktop.dci
@@ -1,0 +1,1 @@
+folder-desktop.dci

--- a/bloom/dsg-icons/bloom/user-desktop.dci
+++ b/bloom/dsg-icons/bloom/user-desktop.dci
@@ -1,0 +1,1 @@
+folder-desktop.dci

--- a/vintage/dsg-icons/vintage/user-desktop.dci
+++ b/vintage/dsg-icons/vintage/user-desktop.dci
@@ -1,0 +1,1 @@
+folder-desktop.dci


### PR DESCRIPTION
Added symbolic links for user-desktop.dci pointing to folder-desktop.dci in three icon theme directories: bloom-dark, bloom, and vintage. This creates consistent desktop folder icons across different theme variants by reusing the existing folder-desktop icon design rather than duplicating files.

feat: 为图标主题添加 user-desktop 符号链接

在三个图标主题目录（bloom-dark、bloom 和 vintage）中添加了指向 folder- desktop.dci 的 user-desktop.dci 符号链接。通过重用现有的 folder-desktop 图标设计而不是复制文件，在不同主题变体中创建一致的桌面文件夹图标。

pms: BUG-332123

## Summary by Sourcery

New Features:
- Add user-desktop.dci symlinks pointing to folder-desktop.dci in bloom-dark, bloom, and vintage icon themes to unify desktop folder icons across variants