### PR TITLE
chore: bump version to 1.1.16

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-theme (1.1.16) unstable; urgency=medium
+
+  * feat: add user-desktop symlinks for icon themes
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 18 Sep 2025 20:05:24 +0800
+
 deepin-desktop-theme (1.1.15) unstable; urgency=medium
 
   * fix: remove exit call in postinst script


### PR DESCRIPTION
update changelog to 1.1.16

## Summary by Sourcery

Build:
- Update Debian changelog to reflect version 1.1.16