### PR TITLE
fix: improve icon file synchronization logic

### DIFF
--- a/tools/xdgicon2dci/main.cpp
+++ b/tools/xdgicon2dci/main.cpp
@@ -260,9 +260,13 @@ void XDGIcon2Dci::copyDciFiles(const QString &fromDir, QMap<QString, QString> &r
         bool needCopy = false;
         if (!QFile::exists(targetPath)) {
             needCopy = true;
-        } else if (recordCache.contains(iconName) 
-            && recordCache.value(iconName) != newFileHash) {
-            needCopy = true;
+        } else if (recordCache.contains(iconName)) {
+            QString targetFileHash = getFileHash(targetPath);
+            if (targetFileHash != recordCache.value(iconName)) { // 记录的hash和目前已经存在文件hash不一致，说明目标文件已经被其他操作修改，不再跟踪
+                recordCache.remove(iconName);
+            } else if (recordCache.value(iconName) != newFileHash) {
+                needCopy = true;
+            }
         }
 
         if (needCopy) {


### PR DESCRIPTION
1. Add target file hash verification before copying icons
2. Remove corrupted cache entries when target file has been modified externally
3. Prevent overwriting files that were changed by other processes
4. Maintain cache integrity by detecting external modifications

fix: 改进图标文件同步逻辑

1. 在复制图标前添加目标文件哈希验证
2. 当目标文件被外部修改时移除损坏的缓存条目
3. 防止覆盖被其他进程更改的文件
4. 通过检测外部修改来维护缓存完整性

## Summary by Sourcery

Improve icon file synchronization by adding hash validation, cleaning up stale cache entries on external changes, and safeguarding against unintended overwrites

Enhancements:
- Verify target file hash before copying icons
- Remove corrupted cache entries when the target file is modified externally
- Prevent overwriting icon files that were changed by other processes
- Maintain cache integrity by detecting external file modifications