### PR TITLE
chore: update changelog to 1.1.30

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-theme (1.1.30) unstable; urgency=medium
+
+  * feat: add Firefox icons for NAL and ZH locales
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 09 Apr 2026 20:29:34 +0800
+
 deepin-desktop-theme (1.1.29) unstable; urgency=medium
 
   * fix: prevent deb file overwrite and improve packaging


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.1.30

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.1.30
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 1.1.30 targeting master.