### PR TITLE
chore: add hardening build flags for security

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,11 @@ export QT_SELECT=5
 
 include /usr/share/dpkg/default.mk
 
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall -Wl,-E -fPIE
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall -Wl,-E -fPIE
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,noexecstack -pie
+
 %:
 	dh $@ --buildsystem=cmake
 


### PR DESCRIPTION
Add security hardening compilation parameters to the Debian packaging rules:
1. Enable full hardening via DEB_BUILD_MAINT_OPTIONS (enables PIE, bindnow, fortify, relro)
2. Add -Wall -Wl,-E -fPIE to CFLAGS for warnings and position- independent code
3. Add -Wall -Wl,-E -fPIE to CXXFLAGS for C++ warnings and position- independent code
4. Add -Wl,--as-needed -Wl,-z,noexecstack -pie to LDFLAGS for linker optimizations and security

These changes aim to improve the package's security posture by enabling various compiler and linker hardening features that help mitigate common vulnerabilities such as buffer overflows, code injection, and stack- based attacks.

Influence:
1. Verify the build completes successfully with the new hardening flags
2. Check that produced binaries are position-independent executables (PIE)
3. Confirm that RELRO (Relocation Read-Only) protection is enabled
4. Test that the package functions correctly on both 32-bit and 64- bit systems
5. Verify that no unexpected build warnings or errors are introduced
6. Ensure backward compatibility with existing system libraries

chore: 添加安全编译参数

在 Debian 打包规则中添加安全加固编译参数：
1. 通过 DEB_BUILD_MAINT_OPTIONS 启用全面安全加固（包括 PIE、bindnow、 fortify、relro）
2. 为 CFLAGS 添加 -Wall -Wl,-E -fPIE 参数，增强警告和位置无关代码支持
3. 为 CXXFLAGS 添加 -Wall -Wl,-E -fPIE 参数，提供 C++ 警告和位置无关代码 支持
4. 为 LDFLAGS 添加 -Wl,--as-needed -Wl,-z,noexecstack -pie 参数，优化链 接和安全性

这些改动旨在通过启用编译器和链接器的安全加固特性，提升软件包的安全防护能
力，有助于缓解缓冲区溢出、代码注入和基于栈的攻击等常见安全漏洞。

Influence:
1. 验证使用新的安全参数后构建是否成功完成
2. 确认生成的可执行文件为位置无关可执行文件（PIE）
3. 确认已启用 RELRO（重载只读）保护机制
4. 测试软件包在 32 位和 64 位系统上的正常运行
5. 验证没有引入意外的构建警告或错误
6. 确保与现有系统库的向后兼容性

PMS: BUG-366931
Change-Id: Icf44729810df0e5d154f5ab269a70466140a061e

## Summary by Sourcery

Build:
- Enable Debian hardening options and additional compiler/linker flags in debian/rules to produce more secure PIE binaries.